### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,30 @@ You may want to use ` --force` option to overwrite the existing module. if you u
 php artisan module:build MODULE_NAME --force
 ```
 
+### Remove Module
+
+To remove a module, use the following command. This will permanently delete the module directory and remove it from the status file.
+
+```bash
+php artisan module:remove MODULE_NAME
+```
+
+### Disable Module
+
+To disable a module, use the following command. This will set the module status to `false` in the `modules_statuses.json` file.
+
+```bash
+php artisan module:disable MODULE_NAME
+```
+
+### Enable Module
+
+To enable a module, use the following command. This will set the module status to `true` in the `modules_statuses.json` file.
+
+```bash
+php artisan module:enable MODULE_NAME
+```
+
 ### Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/nasirkhan/module-manager.svg?style=flat-square)](https://packagist.org/packages/nasirkhan/module-manager)
 
-**Module Manager** is used to manage and generate `Module` for the ***Laravel Starter***. [Laravel Starter](https://github.com/nasirkhan/laravel-starter) is a CMS-like modular starter boilerplate application project, built with the latest release of Laravel. This package is preinstalled with the Laravel Starter. 
+**Module Manager** is used to manage and generate `Module` for the ***Laravel Starter***. 
+
+[Laravel Starter](https://github.com/nasirkhan/laravel-starter) is a CMS-like modular starter boilerplate application project, built with the latest release of Laravel. This package is preinstalled with the Laravel Starter. 
 
 | **Laravel** | **module-manager** |
 |-------------|---------------------|

--- a/src/Commands/ModuleDisableCommand.php
+++ b/src/Commands/ModuleDisableCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Nasirkhan\ModuleManager\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class ModuleDisableCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'module:disable {moduleName : The name of the module to be disabled}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Disable an existing module.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $moduleName = Str::ucfirst(Str::singular(Str::studly($this->argument('moduleName'))));
+
+        $destination = base_path('modules_statuses.json');
+
+        if (! File::exists($destination)) {
+            $this->components->error("Module status file not found.");
+            return;
+        }
+
+        $content = json_decode(File::get($destination), true);
+
+        if (! isset($content[$moduleName])) {
+            $this->components->error("Module {$moduleName} not found in status file.");
+            return;
+        }
+
+        if ($content[$moduleName] === false) {
+            $this->components->info("Module {$moduleName} is already disabled.");
+            return;
+        }
+
+        $content[$moduleName] = false;
+        File::put($destination, json_encode($content, JSON_PRETTY_PRINT));
+
+        $this->components->info("Module {$moduleName} disabled successfully.");
+    }
+}

--- a/src/Commands/ModuleDisableCommand.php
+++ b/src/Commands/ModuleDisableCommand.php
@@ -34,7 +34,8 @@ class ModuleDisableCommand extends Command
         $destination = base_path('modules_statuses.json');
 
         if (! File::exists($destination)) {
-            $this->components->error("Module status file not found.");
+            $this->components->error('Module status file not found.');
+
             return;
         }
 
@@ -42,11 +43,13 @@ class ModuleDisableCommand extends Command
 
         if (! isset($content[$moduleName])) {
             $this->components->error("Module {$moduleName} not found in status file.");
+
             return;
         }
 
         if ($content[$moduleName] === false) {
             $this->components->info("Module {$moduleName} is already disabled.");
+
             return;
         }
 

--- a/src/Commands/ModuleEnableCommand.php
+++ b/src/Commands/ModuleEnableCommand.php
@@ -34,7 +34,8 @@ class ModuleEnableCommand extends Command
         $destination = base_path('modules_statuses.json');
 
         if (! File::exists($destination)) {
-            $this->components->error("Module status file not found.");
+            $this->components->error('Module status file not found.');
+
             return;
         }
 
@@ -42,11 +43,13 @@ class ModuleEnableCommand extends Command
 
         if (! isset($content[$moduleName])) {
             $this->components->error("Module {$moduleName} not found in status file.");
+
             return;
         }
 
         if ($content[$moduleName] === true) {
             $this->components->info("Module {$moduleName} is already enabled.");
+
             return;
         }
 

--- a/src/Commands/ModuleEnableCommand.php
+++ b/src/Commands/ModuleEnableCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Nasirkhan\ModuleManager\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class ModuleEnableCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'module:enable {moduleName : The name of the module to be enabled}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Enable an existing module.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $moduleName = Str::ucfirst(Str::singular(Str::studly($this->argument('moduleName'))));
+
+        $destination = base_path('modules_statuses.json');
+
+        if (! File::exists($destination)) {
+            $this->components->error("Module status file not found.");
+            return;
+        }
+
+        $content = json_decode(File::get($destination), true);
+
+        if (! isset($content[$moduleName])) {
+            $this->components->error("Module {$moduleName} not found in status file.");
+            return;
+        }
+
+        if ($content[$moduleName] === true) {
+            $this->components->info("Module {$moduleName} is already enabled.");
+            return;
+        }
+
+        $content[$moduleName] = true;
+        File::put($destination, json_encode($content, JSON_PRETTY_PRINT));
+
+        $this->components->info("Module {$moduleName} enabled successfully.");
+    }
+}

--- a/src/Commands/ModuleRemoveCommand.php
+++ b/src/Commands/ModuleRemoveCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Nasirkhan\ModuleManager\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class ModuleRemoveCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'module:remove {moduleName : The name of the module to be removed} {--force : Force the operation to run when in production}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove an existing module.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $moduleName = Str::ucfirst(Str::singular(Str::studly($this->argument('moduleName'))));
+        $config = config('module-manager');
+        $namespace = $config['namespace'];
+        $basePath = $namespace . '/' . $moduleName;
+
+        if (! File::isDirectory($basePath)) {
+            $this->components->error("Module {$moduleName} does not exist.");
+            return;
+        }
+
+        if (! $this->option('force')) {
+            if (! $this->components->confirm("Are you sure you want to remove the module {$moduleName}? This will permanently delete all files and cannot be undone.")) {
+                $this->components->info('Operation cancelled.');
+                return;
+            }
+        }
+
+        $this->components->task("Removing Module: {$moduleName}", function () use ($basePath) {
+            File::deleteDirectory($basePath);
+        });
+
+        $this->removeModuleFromStatus($moduleName);
+
+        $this->components->info("Module {$moduleName} removed successfully.");
+    }
+
+    protected function removeModuleFromStatus($moduleName)
+    {
+        $destination = base_path('modules_statuses.json');
+
+        if (File::exists($destination)) {
+            $content = json_decode(File::get($destination), true);
+            if (isset($content[$moduleName])) {
+                unset($content[$moduleName]);
+                File::put($destination, json_encode($content, JSON_PRETTY_PRINT));
+            }
+        }
+    }
+}

--- a/src/Commands/ModuleRemoveCommand.php
+++ b/src/Commands/ModuleRemoveCommand.php
@@ -32,16 +32,18 @@ class ModuleRemoveCommand extends Command
         $moduleName = Str::ucfirst(Str::singular(Str::studly($this->argument('moduleName'))));
         $config = config('module-manager');
         $namespace = $config['namespace'];
-        $basePath = $namespace . '/' . $moduleName;
+        $basePath = $namespace.'/'.$moduleName;
 
         if (! File::isDirectory($basePath)) {
             $this->components->error("Module {$moduleName} does not exist.");
+
             return;
         }
 
         if (! $this->option('force')) {
             if (! $this->components->confirm("Are you sure you want to remove the module {$moduleName}? This will permanently delete all files and cannot be undone.")) {
                 $this->components->info('Operation cancelled.');
+
                 return;
             }
         }

--- a/src/ModuleManagerServiceProvider.php
+++ b/src/ModuleManagerServiceProvider.php
@@ -27,11 +27,11 @@ class ModuleManagerServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__ . '/../config/config.php' => config_path('module-manager.php'),
+                __DIR__.'/../config/config.php' => config_path('module-manager.php'),
             ], 'module-manager');
 
             $this->publishes([
-                __DIR__ . '/stubs' => base_path('stubs/laravel-starter-stubs'),
+                __DIR__.'/stubs' => base_path('stubs/laravel-starter-stubs'),
             ], 'stubs');
 
             // Publishing the views.
@@ -85,7 +85,7 @@ class ModuleManagerServiceProvider extends ServiceProvider
     public function register()
     {
         // Automatically apply the package configuration
-        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'module-manager');
+        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'module-manager');
 
         // Register the main class to use with the facade
         $this->app->singleton('module-manager', function () {
@@ -103,7 +103,7 @@ class ModuleManagerServiceProvider extends ServiceProvider
 
         foreach ($modules as $module => $status) {
             if ($status) {
-                $this->app->register('\Modules\\' . $module . '\Providers\\' . $module . 'ServiceProvider');
+                $this->app->register('\Modules\\'.$module.'\Providers\\'.$module.'ServiceProvider');
             }
         }
     }

--- a/src/ModuleManagerServiceProvider.php
+++ b/src/ModuleManagerServiceProvider.php
@@ -27,11 +27,11 @@ class ModuleManagerServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/../config/config.php' => config_path('module-manager.php'),
+                __DIR__ . '/../config/config.php' => config_path('module-manager.php'),
             ], 'module-manager');
 
             $this->publishes([
-                __DIR__.'/stubs' => base_path('stubs/laravel-starter-stubs'),
+                __DIR__ . '/stubs' => base_path('stubs/laravel-starter-stubs'),
             ], 'stubs');
 
             // Publishing the views.
@@ -65,6 +65,15 @@ class ModuleManagerServiceProvider extends ServiceProvider
                     // Module Build Command to Create Module
                     ModuleBuildCommand::class,
 
+                    // Module Remove Command
+                    Commands\ModuleRemoveCommand::class,
+
+                    // Module Disable Command
+                    Commands\ModuleDisableCommand::class,
+
+                    // Module Enable Command
+                    Commands\ModuleEnableCommand::class,
+
                 ]);
             }
         }
@@ -76,7 +85,7 @@ class ModuleManagerServiceProvider extends ServiceProvider
     public function register()
     {
         // Automatically apply the package configuration
-        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'module-manager');
+        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'module-manager');
 
         // Register the main class to use with the facade
         $this->app->singleton('module-manager', function () {
@@ -94,7 +103,7 @@ class ModuleManagerServiceProvider extends ServiceProvider
 
         foreach ($modules as $module => $status) {
             if ($status) {
-                $this->app->register('\Modules\\'.$module.'\Providers\\'.$module.'ServiceProvider');
+                $this->app->register('\Modules\\' . $module . '\Providers\\' . $module . 'ServiceProvider');
             }
         }
     }


### PR DESCRIPTION
This pull request adds new features to the module management system, enhancing its functionality and improving documentation. The most significant changes include the introduction of commands to enable, disable, and remove modules, along with updates to the documentation to explain these new commands.

### New Module Management Commands

* Added `ModuleRemoveCommand`, allowing users to permanently delete a module and remove it from the status file. This command includes a confirmation prompt and a `--force` option for production environments. (`src/Commands/ModuleRemoveCommand.php`, `src/ModuleManagerServiceProvider.php`) [[1]](diffhunk://#diff-a6d49eef46f66f57c70051ce0d16e505d0e81f70614bc788ed8c389c16a1aa43R1-R72) [[2]](diffhunk://#diff-d407f29be65751045acd703fd1bd777c31494ac39240a1ecb03acb8e6c4f0d67R68-R76)
* Added `ModuleDisableCommand`, enabling users to set a module's status to disabled (`false`) in the `modules_statuses.json` file. (`src/Commands/ModuleDisableCommand.php`, `src/ModuleManagerServiceProvider.php`) [[1]](diffhunk://#diff-3a347d62ff7401f5f29140a046a9b082c43bebcc3a7e3cbb4d27af31b8696f4dR1-R61) [[2]](diffhunk://#diff-d407f29be65751045acd703fd1bd777c31494ac39240a1ecb03acb8e6c4f0d67R68-R76)
* Added `ModuleEnableCommand`, allowing users to set a module's status to enabled (`true`) in the `modules_statuses.json` file. (`src/Commands/ModuleEnableCommand.php`, `src/ModuleManagerServiceProvider.php`) [[1]](diffhunk://#diff-712517265a5f89436f9ea81ad210e0f3562e2e54fbea86b564a77ef024180119R1-R61) [[2]](diffhunk://#diff-d407f29be65751045acd703fd1bd777c31494ac39240a1ecb03acb8e6c4f0d67R68-R76)

### Documentation Updates

* Updated `README.md` to document the new `remove`, `disable`, and `enable` module commands, including usage instructions and descriptions of their effects.
* Improved the organization of the introduction in `README.md` for clarity by separating the explanation of the module manager and the Laravel Starter project.