### PR TITLE
New module management commands

### DIFF
--- a/src/Commands/ModuleBuildCommand.php
+++ b/src/Commands/ModuleBuildCommand.php
@@ -66,7 +66,7 @@ class ModuleBuildCommand extends Command
 
     public function generate($moduleName, $force)
     {
-        $this->components->info('Generating module: ' . $moduleName);
+        $this->components->info('Generating module: '.$moduleName);
         // $this->info('Generating module: '.$moduleName."\n");
 
         $config = config('module-manager');
@@ -83,7 +83,7 @@ class ModuleBuildCommand extends Command
         $search = ['{{moduleName}}', '{{moduleNamePlural}}', '{{moduleNameLower}}', '{{moduleNameLowerPlural}}', '{{namespace}}', '{{composerVendor}}', '{{composerAuthor}}', '{{composerAuthorEmail}}'];
         $replace = [$moduleName, $moduleNamePlural, $moduleNameLower, $moduleNameLowerPlural, $namespace, $composerVendor, $composerAuthor, $composerAuthorEmail];
 
-        $basePath = $namespace . '/' . $moduleName;
+        $basePath = $namespace.'/'.$moduleName;
 
         if (File::isDirectory($basePath)) {
             if ($force) {
@@ -127,9 +127,9 @@ class ModuleBuildCommand extends Command
         $files_list = $config['module']['files'];
 
         foreach ($files_list as $file => $file_path) {
-            $stubFile = "$stubs_path/" . $file_path[0];
+            $stubFile = "$stubs_path/".$file_path[0];
 
-            if (! File::exists($stubFile) && File::exists($stubFile . '.php')) {
+            if (! File::exists($stubFile) && File::exists($stubFile.'.php')) {
                 $stubFile .= '.php';
             }
 
@@ -143,18 +143,18 @@ class ModuleBuildCommand extends Command
 
             $destination_value = $this->setFilePath($file, $file_path[1], $moduleName);
 
-            $destination = "$basePath/" . $this->setFilePath($file, $file_path[1], $moduleName);
+            $destination = "$basePath/".$this->setFilePath($file, $file_path[1], $moduleName);
 
             $pathToFile = $destination_value;
 
             if (count(explode('/', $pathToFile)) > 1) {
                 $fileName = basename($pathToFile);
 
-                $folders = explode('/', str_replace('/' . $fileName, '', $pathToFile));
+                $folders = explode('/', str_replace('/'.$fileName, '', $pathToFile));
 
                 $currentFolder = "$basePath/";
                 foreach ($folders as $folder) {
-                    $currentFolder .= $folder . DIRECTORY_SEPARATOR;
+                    $currentFolder .= $folder.DIRECTORY_SEPARATOR;
 
                     if (! File::isDirectory($currentFolder)) {
                         File::makeDirectory($currentFolder);
@@ -187,42 +187,42 @@ class ModuleBuildCommand extends Command
 
         switch ($filetype) {
             case 'command':
-                $value = $moduleName . 'Command.php';
+                $value = $moduleName.'Command.php';
                 $filePath = str_replace('StubCommand.php', $value, $filePath);
                 break;
 
             case 'database':
-                $value = date('Y_m_d_his_') . 'create_' . $moduleNameLowerPlural . '_table.php';
+                $value = date('Y_m_d_his_').'create_'.$moduleNameLowerPlural.'_table.php';
                 $filePath = str_replace('stubMigration.php', $value, $filePath);
                 break;
 
             case 'factories':
-                $value = $moduleName . 'Factory.php';
+                $value = $moduleName.'Factory.php';
                 $filePath = str_replace('stubFactory.php', $value, $filePath);
                 break;
 
             case 'seeders':
-                $value = $moduleName . 'DatabaseSeeder.php';
+                $value = $moduleName.'DatabaseSeeder.php';
                 $filePath = str_replace('stubSeeders.php', $value, $filePath);
                 break;
 
             case 'models':
-                $value = $moduleName . '.php';
+                $value = $moduleName.'.php';
                 $filePath = str_replace('stubModel.php', $value, $filePath);
                 break;
 
             case 'providers':
-                $value = $moduleName . 'ServiceProvider.php';
+                $value = $moduleName.'ServiceProvider.php';
                 $filePath = str_replace('stubServiceProvider.php', $value, $filePath);
                 break;
 
             case 'controller_backend':
-                $value = $moduleNamePlural . 'Controller.php';
+                $value = $moduleNamePlural.'Controller.php';
                 $filePath = str_replace('stubBackendController.php', $value, $filePath);
                 break;
 
             case 'controller_frontend':
-                $value = $moduleNamePlural . 'Controller.php';
+                $value = $moduleNamePlural.'Controller.php';
                 $filePath = str_replace('stubFrontendController.php', $value, $filePath);
                 break;
 

--- a/src/Commands/ModuleBuildCommand.php
+++ b/src/Commands/ModuleBuildCommand.php
@@ -66,7 +66,7 @@ class ModuleBuildCommand extends Command
 
     public function generate($moduleName, $force)
     {
-        $this->components->info('Generating module: ' . $moduleName);
+        $this->components->info('Generating module: '.$moduleName);
         // $this->info('Generating module: '.$moduleName."\n");
 
         $config = config('module-manager');
@@ -83,7 +83,7 @@ class ModuleBuildCommand extends Command
         $search = ['{{moduleName}}', '{{moduleNamePlural}}', '{{moduleNameLower}}', '{{moduleNameLowerPlural}}', '{{namespace}}', '{{composerVendor}}', '{{composerAuthor}}', '{{composerAuthorEmail}}'];
         $replace = [$moduleName, $moduleNamePlural, $moduleNameLower, $moduleNameLowerPlural, $namespace, $composerVendor, $composerAuthor, $composerAuthorEmail];
 
-        $basePath = $namespace . '/' . $moduleName;
+        $basePath = $namespace.'/'.$moduleName;
 
         if (File::isDirectory($basePath)) {
             if ($force) {
@@ -127,14 +127,15 @@ class ModuleBuildCommand extends Command
         $files_list = $config['module']['files'];
 
         foreach ($files_list as $file => $file_path) {
-            $stubFile = "$stubs_path/" . $file_path[0];
+            $stubFile = "$stubs_path/".$file_path[0];
 
-            if (! File::exists($stubFile) && File::exists($stubFile . '.php')) {
+            if (! File::exists($stubFile) && File::exists($stubFile.'.php')) {
                 $stubFile .= '.php';
             }
 
             if (! File::exists($stubFile)) {
                 $this->components->warn("Stub file not found: {$stubFile}. Skipping...");
+
                 continue;
             }
 
@@ -143,18 +144,18 @@ class ModuleBuildCommand extends Command
 
             $destination_value = $this->setFilePath($file, $file_path[1], $moduleName);
 
-            $destination = "$basePath/" . $this->setFilePath($file, $file_path[1], $moduleName);
+            $destination = "$basePath/".$this->setFilePath($file, $file_path[1], $moduleName);
 
             $pathToFile = $destination_value;
 
             if (count(explode('/', $pathToFile)) > 1) {
                 $fileName = basename($pathToFile);
 
-                $folders = explode('/', str_replace('/' . $fileName, '', $pathToFile));
+                $folders = explode('/', str_replace('/'.$fileName, '', $pathToFile));
 
                 $currentFolder = "$basePath/";
                 foreach ($folders as $folder) {
-                    $currentFolder .= $folder . DIRECTORY_SEPARATOR;
+                    $currentFolder .= $folder.DIRECTORY_SEPARATOR;
 
                     if (! File::isDirectory($currentFolder)) {
                         File::makeDirectory($currentFolder);
@@ -187,42 +188,42 @@ class ModuleBuildCommand extends Command
 
         switch ($filetype) {
             case 'command':
-                $value = $moduleName . 'Command.php';
+                $value = $moduleName.'Command.php';
                 $filePath = str_replace('StubCommand.php', $value, $filePath);
                 break;
 
             case 'database':
-                $value = date('Y_m_d_his_') . 'create_' . $moduleNameLowerPlural . '_table.php';
+                $value = date('Y_m_d_his_').'create_'.$moduleNameLowerPlural.'_table.php';
                 $filePath = str_replace('stubMigration.php', $value, $filePath);
                 break;
 
             case 'factories':
-                $value = $moduleName . 'Factory.php';
+                $value = $moduleName.'Factory.php';
                 $filePath = str_replace('stubFactory.php', $value, $filePath);
                 break;
 
             case 'seeders':
-                $value = $moduleName . 'DatabaseSeeder.php';
+                $value = $moduleName.'DatabaseSeeder.php';
                 $filePath = str_replace('stubSeeders.php', $value, $filePath);
                 break;
 
             case 'models':
-                $value = $moduleName . '.php';
+                $value = $moduleName.'.php';
                 $filePath = str_replace('stubModel.php', $value, $filePath);
                 break;
 
             case 'providers':
-                $value = $moduleName . 'ServiceProvider.php';
+                $value = $moduleName.'ServiceProvider.php';
                 $filePath = str_replace('stubServiceProvider.php', $value, $filePath);
                 break;
 
             case 'controller_backend':
-                $value = $moduleNamePlural . 'Controller.php';
+                $value = $moduleNamePlural.'Controller.php';
                 $filePath = str_replace('stubBackendController.php', $value, $filePath);
                 break;
 
             case 'controller_frontend':
-                $value = $moduleNamePlural . 'Controller.php';
+                $value = $moduleNamePlural.'Controller.php';
                 $filePath = str_replace('stubFrontendController.php', $value, $filePath);
                 break;
 

--- a/src/Commands/ModuleBuildCommand.php
+++ b/src/Commands/ModuleBuildCommand.php
@@ -66,7 +66,7 @@ class ModuleBuildCommand extends Command
 
     public function generate($moduleName, $force)
     {
-        $this->components->info('Generating module: '.$moduleName);
+        $this->components->info('Generating module: ' . $moduleName);
         // $this->info('Generating module: '.$moduleName."\n");
 
         $config = config('module-manager');
@@ -83,7 +83,7 @@ class ModuleBuildCommand extends Command
         $search = ['{{moduleName}}', '{{moduleNamePlural}}', '{{moduleNameLower}}', '{{moduleNameLowerPlural}}', '{{namespace}}', '{{composerVendor}}', '{{composerAuthor}}', '{{composerAuthorEmail}}'];
         $replace = [$moduleName, $moduleNamePlural, $moduleNameLower, $moduleNameLowerPlural, $namespace, $composerVendor, $composerAuthor, $composerAuthorEmail];
 
-        $basePath = $namespace.'/'.$moduleName;
+        $basePath = $namespace . '/' . $moduleName;
 
         if (File::isDirectory($basePath)) {
             if ($force) {
@@ -106,6 +106,12 @@ class ModuleBuildCommand extends Command
         }
 
         $this->enableModule($moduleName);
+
+        $this->call('auth:permissions', [
+            'name' => $moduleNameLowerPlural,
+        ]);
+
+        $this->call('permission:cache-reset');
     }
 
     public function createFiles($moduleName, $basePath, $search, $replace, $force)
@@ -121,9 +127,9 @@ class ModuleBuildCommand extends Command
         $files_list = $config['module']['files'];
 
         foreach ($files_list as $file => $file_path) {
-            $stubFile = "$stubs_path/".$file_path[0];
+            $stubFile = "$stubs_path/" . $file_path[0];
 
-            if (! File::exists($stubFile) && File::exists($stubFile.'.php')) {
+            if (! File::exists($stubFile) && File::exists($stubFile . '.php')) {
                 $stubFile .= '.php';
             }
 
@@ -137,18 +143,18 @@ class ModuleBuildCommand extends Command
 
             $destination_value = $this->setFilePath($file, $file_path[1], $moduleName);
 
-            $destination = "$basePath/".$this->setFilePath($file, $file_path[1], $moduleName);
+            $destination = "$basePath/" . $this->setFilePath($file, $file_path[1], $moduleName);
 
             $pathToFile = $destination_value;
 
             if (count(explode('/', $pathToFile)) > 1) {
                 $fileName = basename($pathToFile);
 
-                $folders = explode('/', str_replace('/'.$fileName, '', $pathToFile));
+                $folders = explode('/', str_replace('/' . $fileName, '', $pathToFile));
 
                 $currentFolder = "$basePath/";
                 foreach ($folders as $folder) {
-                    $currentFolder .= $folder.DIRECTORY_SEPARATOR;
+                    $currentFolder .= $folder . DIRECTORY_SEPARATOR;
 
                     if (! File::isDirectory($currentFolder)) {
                         File::makeDirectory($currentFolder);
@@ -181,42 +187,42 @@ class ModuleBuildCommand extends Command
 
         switch ($filetype) {
             case 'command':
-                $value = $moduleName.'Command.php';
+                $value = $moduleName . 'Command.php';
                 $filePath = str_replace('StubCommand.php', $value, $filePath);
                 break;
 
             case 'database':
-                $value = date('Y_m_d_his_').'create_'.$moduleNameLowerPlural.'_table.php';
+                $value = date('Y_m_d_his_') . 'create_' . $moduleNameLowerPlural . '_table.php';
                 $filePath = str_replace('stubMigration.php', $value, $filePath);
                 break;
 
             case 'factories':
-                $value = $moduleName.'Factory.php';
+                $value = $moduleName . 'Factory.php';
                 $filePath = str_replace('stubFactory.php', $value, $filePath);
                 break;
 
             case 'seeders':
-                $value = $moduleName.'DatabaseSeeder.php';
+                $value = $moduleName . 'DatabaseSeeder.php';
                 $filePath = str_replace('stubSeeders.php', $value, $filePath);
                 break;
 
             case 'models':
-                $value = $moduleName.'.php';
+                $value = $moduleName . '.php';
                 $filePath = str_replace('stubModel.php', $value, $filePath);
                 break;
 
             case 'providers':
-                $value = $moduleName.'ServiceProvider.php';
+                $value = $moduleName . 'ServiceProvider.php';
                 $filePath = str_replace('stubServiceProvider.php', $value, $filePath);
                 break;
 
             case 'controller_backend':
-                $value = $moduleNamePlural.'Controller.php';
+                $value = $moduleNamePlural . 'Controller.php';
                 $filePath = str_replace('stubBackendController.php', $value, $filePath);
                 break;
 
             case 'controller_frontend':
-                $value = $moduleNamePlural.'Controller.php';
+                $value = $moduleNamePlural . 'Controller.php';
                 $filePath = str_replace('stubFrontendController.php', $value, $filePath);
                 break;
 

--- a/src/Commands/ModuleDiffCommand.php
+++ b/src/Commands/ModuleDiffCommand.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Nasirkhan\ModuleManager\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class ModuleDiffCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'module:diff {module : The module to compare}
+                            {--detailed : Show detailed file-by-file comparison}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show differences between package and published module';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $moduleName = $this->argument('module');
+        $packagePath = base_path("vendor/nasirkhan/module-manager/src/Modules/{$moduleName}");
+        $publishedPath = base_path("Modules/{$moduleName}");
+
+        // Check if module exists in package
+        if (! File::exists($packagePath)) {
+            $this->components->error("Module '{$moduleName}' not found in package.");
+
+            return self::FAILURE;
+        }
+
+        // Check if module is published
+        if (! File::exists($publishedPath)) {
+            $this->components->warn("Module '{$moduleName}' has not been published yet.");
+            $this->line('It\'s using the package version (updateable via composer).');
+            $this->newLine();
+            $this->line('To publish: <fg=green>php artisan module:publish '.$moduleName.'</>');
+
+            return self::SUCCESS;
+        }
+
+        // Compare versions
+        $this->newLine();
+        $this->components->twoColumnDetail("<fg=bright-blue>Comparing Module:</> {$moduleName}", '');
+        $this->newLine();
+
+        // Get file lists
+        $packageFiles = $this->getFileList($packagePath);
+        $publishedFiles = $this->getFileList($publishedPath);
+
+        $onlyInPackage = array_diff($packageFiles, $publishedFiles);
+        $onlyInPublished = array_diff($publishedFiles, $packageFiles);
+        $common = array_intersect($packageFiles, $publishedFiles);
+
+        $hasChanges = false;
+
+        // Files only in package (new in package)
+        if (! empty($onlyInPackage)) {
+            $hasChanges = true;
+            $this->components->warn('New files in package (not in your version):');
+            foreach ($onlyInPackage as $file) {
+                $this->line("  <fg=green>+</> {$file}");
+            }
+            $this->newLine();
+        }
+
+        // Files only in published (removed from package or custom)
+        if (! empty($onlyInPublished)) {
+            $hasChanges = true;
+            $this->components->info('Files only in your version:');
+            foreach ($onlyInPublished as $file) {
+                $this->line("  <fg=red>-</> {$file}");
+            }
+            $this->newLine();
+        }
+
+        // Check for modified files
+        $modifiedFiles = $this->getModifiedFiles($packagePath, $publishedPath, $common);
+
+        if (! empty($modifiedFiles)) {
+            $hasChanges = true;
+            $this->components->warn('Modified files:');
+            foreach ($modifiedFiles as $file) {
+                $this->line("  <fg=yellow>M</> {$file}");
+
+                if ($this->option('detailed')) {
+                    $this->showFileDiff($packagePath.'/'.$file, $publishedPath.'/'.$file);
+                }
+            }
+            $this->newLine();
+        }
+
+        // Summary
+        if (! $hasChanges) {
+            $this->components->info('No differences found. Your module matches the package version.');
+        } else {
+            $this->components->warn('Recommendation:');
+            $this->line('  Review the changes above and decide whether to:');
+            $this->line('  - Manually merge new features from package');
+            $this->line('  - Keep your customizations as-is');
+            $this->line('  - Re-publish and re-apply customizations');
+        }
+
+        $this->newLine();
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Get list of files in directory
+     */
+    protected function getFileList(string $path): array
+    {
+        if (! File::exists($path)) {
+            return [];
+        }
+
+        return collect(File::allFiles($path))
+            ->map(fn ($file) => str_replace($path.DIRECTORY_SEPARATOR, '', $file->getPathname()))
+            ->map(fn ($file) => str_replace('\\', '/', $file)) // Normalize path separators
+            ->toArray();
+    }
+
+    /**
+     * Get list of modified files
+     */
+    protected function getModifiedFiles(string $packagePath, string $publishedPath, array $commonFiles): array
+    {
+        $modified = [];
+
+        foreach ($commonFiles as $file) {
+            $packageFile = $packagePath.'/'.$file;
+            $publishedFile = $publishedPath.'/'.$file;
+
+            if (File::exists($packageFile) && File::exists($publishedFile)) {
+                $packageHash = md5_file($packageFile);
+                $publishedHash = md5_file($publishedFile);
+
+                if ($packageHash !== $publishedHash) {
+                    $modified[] = $file;
+                }
+            }
+        }
+
+        return $modified;
+    }
+
+    /**
+     * Show simple diff between two files
+     */
+    protected function showFileDiff(string $file1, string $file2): void
+    {
+        $lines1 = explode("\n", File::get($file1));
+        $lines2 = explode("\n", File::get($file2));
+
+        $maxLines = max(count($lines1), count($lines2));
+
+        $this->line('    <fg=gray>┌─ Diff Preview (first 5 lines) ─────────────────</>>');
+
+        $shownLines = 0;
+        for ($i = 0; $i < min($maxLines, 5); $i++) {
+            $line1 = $lines1[$i] ?? '';
+            $line2 = $lines2[$i] ?? '';
+
+            if ($line1 !== $line2) {
+                if (! empty($line1)) {
+                    $this->line('    <fg=red>  - '.substr($line1, 0, 50).'</>');
+                }
+                if (! empty($line2)) {
+                    $this->line('    <fg=green>  + '.substr($line2, 0, 50).'</>');
+                }
+                $shownLines++;
+            }
+        }
+
+        if ($shownLines === 0) {
+            $this->line('    <fg=gray>  (Differences in whitespace or later in file)</>');
+        }
+
+        $this->line('    <fg=gray>└────────────────────────────────────────────────</>>');
+        $this->newLine();
+    }
+}

--- a/src/Commands/ModuleDiffCommand.php
+++ b/src/Commands/ModuleDiffCommand.php
@@ -116,7 +116,7 @@ class ModuleDiffCommand extends Command
     }
 
     /**
-     * Get list of files in directory
+     * Get list of files in directory.
      */
     protected function getFileList(string $path): array
     {
@@ -131,7 +131,7 @@ class ModuleDiffCommand extends Command
     }
 
     /**
-     * Get list of modified files
+     * Get list of modified files.
      */
     protected function getModifiedFiles(string $packagePath, string $publishedPath, array $commonFiles): array
     {
@@ -155,7 +155,7 @@ class ModuleDiffCommand extends Command
     }
 
     /**
-     * Show simple diff between two files
+     * Show simple diff between two files.
      */
     protected function showFileDiff(string $file1, string $file2): void
     {

--- a/src/Commands/ModulePublishCommand.php
+++ b/src/Commands/ModulePublishCommand.php
@@ -74,7 +74,7 @@ class ModulePublishCommand extends Command
     }
 
     /**
-     * Update module status in modules_statuses.json
+     * Update module status in modules_statuses.json.
      */
     protected function updateModuleStatus(string $module, bool $published): void
     {
@@ -94,7 +94,7 @@ class ModulePublishCommand extends Command
     }
 
     /**
-     * Get module version from composer.json or service provider
+     * Get module version from composer.json or service provider.
      */
     protected function getModuleVersion(string $module): string
     {
@@ -111,7 +111,7 @@ class ModulePublishCommand extends Command
     }
 
     /**
-     * List available modules in package
+     * List available modules in package.
      */
     protected function listAvailableModules(): void
     {

--- a/src/Commands/ModulePublishCommand.php
+++ b/src/Commands/ModulePublishCommand.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Nasirkhan\ModuleManager\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class ModulePublishCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'module:publish {module : The name of the module to publish}
+                            {--force : Overwrite existing published module}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish a module from vendor to Modules directory for customization';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $moduleName = $this->argument('module');
+        $sourcePath = base_path("vendor/nasirkhan/module-manager/src/Modules/{$moduleName}");
+        $destinationPath = base_path("Modules/{$moduleName}");
+
+        // Check if module exists in package
+        if (! File::exists($sourcePath)) {
+            $this->error("Module '{$moduleName}' not found in package.");
+            $this->line('Available modules:');
+            $this->listAvailableModules();
+
+            return self::FAILURE;
+        }
+
+        // Check if already published
+        if (File::exists($destinationPath) && ! $this->option('force')) {
+            if (! $this->confirm("Module '{$moduleName}' already exists in Modules/. Overwrite?")) {
+                $this->info('Publishing cancelled.');
+
+                return self::SUCCESS;
+            }
+        }
+
+        // Remove existing if --force or confirmed
+        if (File::exists($destinationPath)) {
+            File::deleteDirectory($destinationPath);
+        }
+
+        // Copy module
+        File::copyDirectory($sourcePath, $destinationPath);
+
+        // Update module status
+        $this->updateModuleStatus($moduleName, true);
+
+        // Success message
+        $this->newLine();
+        $this->components->info("Module '{$moduleName}' published successfully!");
+        $this->line("Location: <fg=gray>{$destinationPath}</>");
+        $this->newLine();
+        $this->components->warn('Note: This module is now user-owned and won\'t be updated via composer.');
+        $this->line('  - You have full control to customize it');
+        $this->line('  - Use <fg=green>php artisan module:diff {$moduleName}</> to see package updates');
+        $this->newLine();
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Update module status in modules_statuses.json
+     */
+    protected function updateModuleStatus(string $module, bool $published): void
+    {
+        $statusFile = base_path('modules_statuses.json');
+        $statuses = File::exists($statusFile)
+            ? json_decode(File::get($statusFile), true)
+            : [];
+
+        $statuses[$module] = [
+            'published' => $published,
+            'published_at' => now()->toISOString(),
+            'location' => 'user',
+            'version' => $this->getModuleVersion($module),
+        ];
+
+        File::put($statusFile, json_encode($statuses, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * Get module version from composer.json or service provider
+     */
+    protected function getModuleVersion(string $module): string
+    {
+        // Try to get from module's composer.json if exists
+        $composerFile = base_path("Modules/{$module}/composer.json");
+        if (File::exists($composerFile)) {
+            $composer = json_decode(File::get($composerFile), true);
+
+            return $composer['version'] ?? '1.0.0';
+        }
+
+        // Default version
+        return '1.0.0';
+    }
+
+    /**
+     * List available modules in package
+     */
+    protected function listAvailableModules(): void
+    {
+        $modulesPath = base_path('vendor/nasirkhan/module-manager/src/Modules');
+
+        if (! File::exists($modulesPath)) {
+            return;
+        }
+
+        $modules = collect(File::directories($modulesPath))
+            ->map(fn ($dir) => basename($dir))
+            ->values();
+
+        if ($modules->isEmpty()) {
+            $this->line('  No modules available in package.');
+
+            return;
+        }
+
+        foreach ($modules as $module) {
+            $this->line("  - {$module}");
+        }
+    }
+}

--- a/src/Commands/ModuleStatusCommand.php
+++ b/src/Commands/ModuleStatusCommand.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Nasirkhan\ModuleManager\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class ModuleStatusCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'module:status {module? : Check specific module status}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show status of all modules (package vs published)';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $specificModule = $this->argument('module');
+
+        if ($specificModule) {
+            return $this->showModuleStatus($specificModule);
+        }
+
+        return $this->showAllModulesStatus();
+    }
+
+    /**
+     * Show status of all modules
+     */
+    protected function showAllModulesStatus(): int
+    {
+        $packageModules = $this->getPackageModules();
+        $publishedModules = $this->getPublishedModules();
+        $allModules = collect($packageModules)->merge($publishedModules)->unique()->sort();
+
+        if ($allModules->isEmpty()) {
+            $this->components->warn('No modules found.');
+
+            return self::SUCCESS;
+        }
+
+        $rows = [];
+
+        foreach ($allModules as $module) {
+            $inPackage = in_array($module, $packageModules);
+            $isPublished = in_array($module, $publishedModules);
+
+            if ($isPublished) {
+                $location = '<fg=yellow>Modules/ (custom)</>';
+                $customized = '<fg=yellow>⚠ Yes</>';
+                $updateStrategy = '<fg=gray>User owns this</>';
+            } elseif ($inPackage) {
+                $location = '<fg=green>vendor (package)</>';
+                $customized = '<fg=green>✓ No</>';
+                $updateStrategy = '<fg=green>Updateable via composer</>';
+            } else {
+                $location = '<fg=red>Unknown</>';
+                $customized = '<fg=red>?</>';
+                $updateStrategy = '<fg=red>Unknown</>';
+            }
+
+            $rows[] = [
+                $module,
+                $location,
+                $customized,
+                $updateStrategy,
+            ];
+        }
+
+        $this->newLine();
+        $this->components->twoColumnDetail('<fg=bright-blue>Module Status Overview</>', '');
+        $this->table(
+            ['Module', 'Location', 'Customized', 'Update Strategy'],
+            $rows
+        );
+
+        $this->newLine();
+        $this->components->info('Commands:');
+        $this->line('  <fg=green>php artisan module:publish {module}</> - Publish a module for customization');
+        $this->line('  <fg=green>php artisan module:diff {module}</>    - See differences between versions');
+        $this->line('  <fg=green>composer update</>                      - Update package modules');
+        $this->newLine();
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Show status of specific module
+     */
+    protected function showModuleStatus(string $module): int
+    {
+        $inPackage = $this->isInPackage($module);
+        $isPublished = $this->isPublished($module);
+
+        if (! $inPackage && ! $isPublished) {
+            $this->components->error("Module '{$module}' not found.");
+
+            return self::FAILURE;
+        }
+
+        $this->newLine();
+        $this->components->twoColumnDetail("<fg=bright-blue>Module:</> {$module}", '');
+        $this->newLine();
+
+        if ($isPublished) {
+            $this->components->twoColumnDetail('Location', '<fg=yellow>Modules/ (custom)</>');
+            $this->components->twoColumnDetail('Customized', '<fg=yellow>Yes</>');
+            $this->components->twoColumnDetail('Update Strategy', '<fg=gray>User owns this</>');
+            $this->newLine();
+
+            if ($inPackage) {
+                $this->components->warn('Package version also exists in vendor/');
+                $this->line('  Run <fg=green>php artisan module:diff '.$module.'</> to see differences');
+            }
+        } elseif ($inPackage) {
+            $this->components->twoColumnDetail('Location', '<fg=green>vendor (package)</>');
+            $this->components->twoColumnDetail('Customized', '<fg=green>No</>');
+            $this->components->twoColumnDetail('Update Strategy', '<fg=green>Updateable via composer</>');
+            $this->newLine();
+            $this->line('  Run <fg=green>php artisan module:publish '.$module.'</> to customize');
+        }
+
+        $this->newLine();
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Get list of package modules
+     */
+    protected function getPackageModules(): array
+    {
+        $path = base_path('vendor/nasirkhan/module-manager/src/Modules');
+
+        if (! File::exists($path)) {
+            return [];
+        }
+
+        return collect(File::directories($path))
+            ->map(fn ($dir) => basename($dir))
+            ->toArray();
+    }
+
+    /**
+     * Get list of published modules
+     */
+    protected function getPublishedModules(): array
+    {
+        $path = base_path('Modules');
+
+        if (! File::exists($path)) {
+            return [];
+        }
+
+        return collect(File::directories($path))
+            ->map(fn ($dir) => basename($dir))
+            ->toArray();
+    }
+
+    /**
+     * Check if module is in package
+     */
+    protected function isInPackage(string $module): bool
+    {
+        return File::exists(base_path("vendor/nasirkhan/module-manager/src/Modules/{$module}"));
+    }
+
+    /**
+     * Check if module is published
+     */
+    protected function isPublished(string $module): bool
+    {
+        return File::exists(base_path("Modules/{$module}"));
+    }
+}

--- a/src/Commands/ModuleStatusCommand.php
+++ b/src/Commands/ModuleStatusCommand.php
@@ -36,7 +36,7 @@ class ModuleStatusCommand extends Command
     }
 
     /**
-     * Show status of all modules
+     * Show status of all modules.
      */
     protected function showAllModulesStatus(): int
     {
@@ -96,7 +96,7 @@ class ModuleStatusCommand extends Command
     }
 
     /**
-     * Show status of specific module
+     * Show status of specific module.
      */
     protected function showModuleStatus(string $module): int
     {
@@ -137,7 +137,7 @@ class ModuleStatusCommand extends Command
     }
 
     /**
-     * Get list of package modules
+     * Get list of package modules.
      */
     protected function getPackageModules(): array
     {
@@ -153,7 +153,7 @@ class ModuleStatusCommand extends Command
     }
 
     /**
-     * Get list of published modules
+     * Get list of published modules.
      */
     protected function getPublishedModules(): array
     {
@@ -169,7 +169,7 @@ class ModuleStatusCommand extends Command
     }
 
     /**
-     * Check if module is in package
+     * Check if module is in package.
      */
     protected function isInPackage(string $module): bool
     {
@@ -177,7 +177,7 @@ class ModuleStatusCommand extends Command
     }
 
     /**
-     * Check if module is published
+     * Check if module is published.
      */
     protected function isPublished(string $module): bool
     {

--- a/src/ModuleManagerServiceProvider.php
+++ b/src/ModuleManagerServiceProvider.php
@@ -7,6 +7,9 @@ use Illuminate\Support\ServiceProvider;
 use Nasirkhan\ModuleManager\Commands\AuthPermissionsCommand;
 use Nasirkhan\ModuleManager\Commands\InsertDemoDataCommand;
 use Nasirkhan\ModuleManager\Commands\ModuleBuildCommand;
+use Nasirkhan\ModuleManager\Commands\ModuleDiffCommand;
+use Nasirkhan\ModuleManager\Commands\ModulePublishCommand;
+use Nasirkhan\ModuleManager\Commands\ModuleStatusCommand;
 
 class ModuleManagerServiceProvider extends ServiceProvider
 {
@@ -73,6 +76,11 @@ class ModuleManagerServiceProvider extends ServiceProvider
 
                     // Module Enable Command
                     Commands\ModuleEnableCommand::class,
+
+                    // Updateability Commands
+                    ModulePublishCommand::class,
+                    ModuleStatusCommand::class,
+                    ModuleDiffCommand::class,
 
                 ]);
             }


### PR DESCRIPTION
This pull request introduces a set of new artisan commands to improve module management, customization, and visibility in the `ModuleManager` package. The main focus is on allowing users to publish package modules for customization, check their status, and compare custom modules with their original package versions. Additionally, relevant commands are registered in the service provider, and minor improvements are made to existing code.

**New module management commands:**

* Added `ModulePublishCommand` (`module:publish`) to allow users to copy a module from the package (`vendor/`) to the `Modules/` directory for customization, with support for overwriting and status tracking.
* Added `ModuleStatusCommand` (`module:status`) to display the status of all modules or a specific module, showing whether they are package-managed or user-customized.
* Added `ModuleDiffCommand` (`module:diff`) to compare a published module against its package version, highlighting added, removed, and modified files, with an option for detailed diffs.

**Service provider registration:**

* Registered the new commands (`ModulePublishCommand`, `ModuleStatusCommand`, `ModuleDiffCommand`) in `ModuleManagerServiceProvider`, making them available via artisan. [[1]](diffhunk://#diff-d407f29be65751045acd703fd1bd777c31494ac39240a1ecb03acb8e6c4f0d67R10-R12) [[2]](diffhunk://#diff-d407f29be65751045acd703fd1bd777c31494ac39240a1ecb03acb8e6c4f0d67R80-R84)

**Enhancements to existing commands:**

* In `ModuleBuildCommand`, after enabling a module, now automatically calls permission generation and resets the permission cache to ensure proper setup.
* Added a minor user feedback improvement in `createFiles` to warn when a stub file is missing before skipping.