### PR TITLE
Database seeding improvements

### DIFF
--- a/src/Modules/Menu/database/seeders/CurrentMenuDataSeeder.php
+++ b/src/Modules/Menu/database/seeders/CurrentMenuDataSeeder.php
@@ -66,14 +66,14 @@ class CurrentMenuDataSeeder extends Seeder
             }
         }
 
-        // Seed menus
+        // Seed menus — forceCreate bypasses guarded 'id' so explicit IDs are preserved
         foreach ($allMenus as $menuData) {
-            Menu::create($menuData);
+            Menu::forceCreate($menuData);
         }
 
-        // Seed menu items
+        // Seed menu items — forceCreate preserves explicit id and parent_id values
         foreach ($allMenuItems as $itemData) {
-            MenuItem::create($itemData);
+            MenuItem::forceCreate($itemData);
         }
 
         // Re-enable foreign key constraints

--- a/src/Modules/Post/database/migrations/2024_04_06_020035_create_posts_table.php
+++ b/src/Modules/Post/database/migrations/2024_04_06_020035_create_posts_table.php
@@ -52,11 +52,6 @@ return new class extends Migration
 
             // Foreign key for category relationship
             // Use nullOnDelete() so posts aren't deleted when category is deleted
-            $table->foreign('category_id')
-                ->references('id')
-                ->on('categories')
-                ->nullOnDelete();
-
             // Foreign keys for audit trail - use noActionOnDelete()
             // to preserve user ID even if user is deleted
             $table->foreign('created_by')

--- a/src/Modules/Post/database/migrations/2024_04_06_031130_add_category_foreign_key_to_posts_table.php
+++ b/src/Modules/Post/database/migrations/2024_04_06_031130_add_category_foreign_key_to_posts_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Separated from create_posts_table to ensure the categories table
+     * already exists when this foreign key constraint is added.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->foreign('category_id')
+                ->references('id')
+                ->on('categories')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropForeign(['category_id']);
+        });
+    }
+};


### PR DESCRIPTION
This pull request addresses improvements in database seeding and migrations for menu and post modules, focusing on data integrity and migration reliability. The most significant changes are the use of `forceCreate` to preserve explicit IDs during seeding, and the separation of a foreign key constraint into its own migration to ensure proper table creation order.

**Database seeding improvements:**

* Updated `CurrentMenuDataSeeder.php` to use `forceCreate` for both `Menu` and `MenuItem` records, ensuring that explicit `id` and `parent_id` values are preserved during seeding.

**Migration reliability and foreign key constraints:**

* Removed the `category_id` foreign key constraint from the original `create_posts_table` migration to avoid issues if the `categories` table does not exist yet.
* Added a new migration (`add_category_foreign_key_to_posts_table.php`) that creates the `category_id` foreign key constraint separately, ensuring the `categories` table is present before adding the constraint. Includes appropriate up and down methods for migration safety.