### PR TITLE
Dev

### DIFF
--- a/src/Modules/Menu/Resources/views/components/dynamic-menu.blade.php
+++ b/src/Modules/Menu/Resources/views/components/dynamic-menu.blade.php
@@ -1,4 +1,4 @@
-@props(['location', 'cssClass' => 'flex flex-col space-y-2 md:flex-row md:space-y-0 md:space-x-8', 'itemComponent' => null])
+@props(['location', 'cssClass' => 'flex flex-col sm:flex-row space-y-2 md:flex-row md:space-y-0 md:space-x-8', 'itemComponent' => null])
 
 @php
     use Nasirkhan\ModuleManager\Modules\Menu\Models\Menu;

--- a/src/Modules/Menu/Resources/views/components/menu-item.blade.php
+++ b/src/Modules/Menu/Resources/views/components/menu-item.blade.php
@@ -36,7 +36,7 @@
     
     @case('dropdown')
         @if($hasChildren)
-            <li class="relative group">
+            <li class="relative group ">
                 <button
                     type="button"
                     class="border-transparent dark:border-transparent cursor-pointer flex items-center justify-between w-full md:w-auto border-b-2 px-3 py-2 font-semibold text-gray-800 transition duration-200 ease-in hover:border-gray-700 hover:opacity-75 dark:text-white dark:hover:border-gray-300 dark:hover:opacity-75 sm:my-0 sm:py-1"
@@ -45,9 +45,9 @@
                     aria-haspopup="true"
                     aria-label="Toggle {{ $item->getDisplayTitle() }} submenu"
                 >
-                    {{ $item->getDisplayTitle() }}
-                    <svg class="w-2.5 h-2.5 ml-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
+                    <span>{{ $item->getDisplayTitle() }}</span>
+                    <svg class="w-6 h-6 ml-2.5 flex-shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m8 10 4 4 4-4"/>
                     </svg>
                 </button>
 

--- a/src/Modules/Menu/database/seeders/CurrentMenuDataSeeder.php
+++ b/src/Modules/Menu/database/seeders/CurrentMenuDataSeeder.php
@@ -3,7 +3,7 @@
 namespace Nasirkhan\ModuleManager\Modules\Menu\database\seeders;
 
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Nasirkhan\ModuleManager\Modules\Menu\Models\Menu;
 use Nasirkhan\ModuleManager\Modules\Menu\Models\MenuItem;
 
@@ -45,8 +45,8 @@ class CurrentMenuDataSeeder extends Seeder
             $this->command->info('Seeding menus and menu items from PHP data...');
         }
 
-        // Disable foreign key constraints
-        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+        // Disable foreign key constraints (works on MySQL, SQLite, PostgreSQL)
+        Schema::disableForeignKeyConstraints();
 
         // Truncate existing data
         MenuItem::truncate();
@@ -77,6 +77,6 @@ class CurrentMenuDataSeeder extends Seeder
         }
 
         // Re-enable foreign key constraints
-        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+        Schema::enableForeignKeyConstraints();
     }
 }


### PR DESCRIPTION
This pull request updates the menu component styles and refactors the foreign key constraint handling in the menu data seeder for improved compatibility and maintainability. The most important changes are grouped below:

**UI and Style Improvements:**

* Updated the default CSS classes in `dynamic-menu.blade.php` to improve responsive layout by adding `sm:flex-row` for better small screen support.
* Enhanced the submenu toggle button in `menu-item.blade.php` by wrapping the display title in a `<span>`, increasing the SVG icon size, and updating its viewbox for better accessibility and visual consistency.

**Seeder Refactoring and Compatibility:**

* Refactored the foreign key constraint management in `CurrentMenuDataSeeder.php` to use Laravel's `Schema` facade instead of raw SQL statements, ensuring compatibility across different database drivers. [[1]](diffhunk://#diff-cbff0dd6b8ca8753dbe8964446bb03578bd5b863783b138abceb6ac7b48e4f58L6-R6) [[2]](diffhunk://#diff-cbff0dd6b8ca8753dbe8964446bb03578bd5b863783b138abceb6ac7b48e4f58L48-R49) [[3]](diffhunk://#diff-cbff0dd6b8ca8753dbe8964446bb03578bd5b863783b138abceb6ac7b48e4f58L80-R80)