### PR TITLE
fix(ModuleManagerServiceProvider): add fallback for module statuses c…

### DIFF
--- a/src/ModuleManagerServiceProvider.php
+++ b/src/ModuleManagerServiceProvider.php
@@ -170,9 +170,15 @@ class ModuleManagerServiceProvider extends ServiceProvider
             File::put($statusFile, json_encode($defaultModules, JSON_PRETTY_PRINT));
         }
 
-        $modules = Cache::remember('module_statuses', 3600, function () use ($statusFile) {
-            return json_decode(File::get($statusFile), true);
-        });
+        try {
+            $modules = Cache::remember('module_statuses', 3600, function () use ($statusFile) {
+                return json_decode(File::get($statusFile), true);
+            });
+        } catch (\Exception $e) {
+            // Cache backend is not ready yet (e.g. during package:discover before migrations run).
+            // Fall back to reading the file directly so bootstrapping never fails.
+            $modules = json_decode(File::get($statusFile), true);
+        }
 
         if (! is_array($modules)) {
             return;


### PR DESCRIPTION

This pull request improves the robustness of the `registerModules` method in `ModuleManagerServiceProvider` by handling potential cache backend failures. The main change ensures that the application can still bootstrap modules even if the cache is unavailable.

Error handling and fallback:

* Wrapped the cache retrieval logic in a `try-catch` block to handle exceptions when the cache backend is not ready, falling back to reading the module status file directly if an error occurs. This prevents bootstrapping failures during early application stages.trapping failures