### PR TITLE
Add 'web' middleware to admin routes for access control

### DIFF
--- a/src/Modules/Settings/routes/web.php
+++ b/src/Modules/Settings/routes/web.php
@@ -18,7 +18,7 @@ use Nasirkhan\ModuleManager\Modules\Settings\Http\Controllers\SettingController;
  * Backend Routes
  * These routes need view-backend permission
  */
-Route::group(['prefix' => 'admin', 'as' => 'backend.', 'middleware' => ['auth', 'can:view_backend']], function () {
+Route::group(['prefix' => 'admin', 'as' => 'backend.', 'middleware' => ['web', 'auth', 'can:view_backend']], function () {
     /*
      * Settings Routes
      */


### PR DESCRIPTION
This pull request makes a minor update to the backend route group in `src/Modules/Settings/routes/web.php`. The change adds the `web` middleware to the existing middleware array for admin routes, ensuring session state, CSRF protection, and other web features are applied to these routes.