### PR TITLE
style(ui): redesign post module frontend views

### DIFF
--- a/src/Modules/Post/Resources/views/frontend/posts/index.blade.php
+++ b/src/Modules/Post/Resources/views/frontend/posts/index.blade.php
@@ -7,80 +7,85 @@
 @section("content")
     <x-cube::header-block :title="__('Articles')">
         <p class="mb-8 leading-relaxed">
-            We publish articles on a number of topics.
+            {{ __("We publish articles on a number of topics.") }}
             <br />
-            We encourage you to read our posts and let us know your feedback. It would be really help us to move
-            forward.
+            {{ __("We encourage you to read our posts and let us know your feedback.") }}
         </p>
     </x-cube::header-block>
 
-    <section class="bg-white p-6 text-gray-600 dark:bg-gray-700 sm:p-20">
-        <div class="grid grid-cols-1 gap-6 sm:grid-cols-3">
-            @foreach ($$module_name as $$module_name_singular)
-                @php
-                    $details_url = route("frontend.$module_name.show", [
-                        encode_id($$module_name_singular->id),
-                        $$module_name_singular->slug,
-                    ]);
-                @endphp
+    <section class="bg-white py-10 text-gray-600 dark:bg-gray-700 sm:py-16">
+        <div class="mx-auto max-w-7xl px-6 sm:px-10">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                @foreach ($$module_name as $$module_name_singular)
+                    @php
+                        $details_url = route("frontend.$module_name.show", [
+                            encode_id($$module_name_singular->id),
+                            $$module_name_singular->slug,
+                        ]);
+                        $authorName = $$module_name_singular->created_by_alias
+                            ?: $$module_name_singular->created_by_name;
+                        $authorUrl = $$module_name_singular->created_by_alias
+                            ? null
+                            : route("frontend.users.profile", $$module_name_singular->created_by);
+                    @endphp
 
-                <x-cube::card
-                    :url="$details_url"
-                    :name="$$module_name_singular->name"
-                    :image="$$module_name_singular->image"
-                >
-                    @if ($$module_name_singular->created_by_alias)
-                        <div class="my-4 flex flex-row items-center">
-                            <img
-                                class="h-5 w-5 rounded-full sm:h-8 sm:w-8"
-                                src="{{ asset("img/avatars/" . rand(1, 8) . ".jpg") }}"
-                                alt="Author profile image"
-                            />
-                            <h6 class="small mb-0 ml-2 text-sm dark:text-gray-400">
-                                {{ $$module_name_singular->created_by_alias }}
-                            </h6>
+                    <x-cube::card
+                        :url="$details_url"
+                        :name="$$module_name_singular->name"
+                        :image="$$module_name_singular->image"
+                    >
+                        {{-- Author + date --}}
+                        <div class="my-3 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                            </svg>
+                            @if ($authorUrl)
+                                <a href="{{ $authorUrl }}" class="hover:text-gray-700 dark:hover:text-gray-200">{{ $authorName }}</a>
+                            @else
+                                <span>{{ $authorName }}</span>
+                            @endif
+                            @if ($$module_name_singular->published_at)
+                                <span class="text-gray-300 dark:text-gray-600">·</span>
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                                </svg>
+                                <span>{{ $$module_name_singular->published_at->format("M j, Y") }}</span>
+                            @endif
                         </div>
-                    @else
-                        <div class="my-4 flex flex-row items-center">
-                            <img
-                                class="h-5 w-5 rounded-full sm:h-8 sm:w-8"
-                                src="{{ asset("img/avatars/" . rand(1, 8) . ".jpg") }}"
-                                alt=""
-                            />
 
-                            <a href="{{ route("frontend.users.profile", $$module_name_singular->created_by) }}">
-                                <h6 class="small mb-0 ml-2 text-sm dark:text-gray-400">
-                                    {{ $$module_name_singular->created_by_name }}
-                                </h6>
+                        {{-- Intro --}}
+                        <p class="mb-3 line-clamp-3 text-sm text-gray-600 dark:text-gray-400">
+                            {{ $$module_name_singular->intro }}
+                        </p>
+
+                        {{-- Category --}}
+                        <div class="mb-2">
+                            <a
+                                href="{{ route('frontend.categories.show', [encode_id($$module_name_singular->category_id), $$module_name_singular->category->slug]) }}"
+                                class="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-700 hover:bg-blue-100 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-900/60"
+                            >
+                                {{ $$module_name_singular->category->name }}
                             </a>
                         </div>
-                    @endif
 
-                    <p class="mb-3 font-normal text-gray-700 dark:text-gray-400">
-                        {{ $$module_name_singular->intro }}
-                    </p>
-                    <p>
-                        <x-cube::badge
-                            :url="route('frontend.categories.show', [
-                                encode_id($$module_name_singular->category_id),
-                                $$module_name_singular->category->slug,
-                            ])"
-                            :text="$$module_name_singular->category->name"
-                        />
-                    </p>
-                    <div class="mt-4">
-                        @foreach ($$module_name_singular->tags as $tag)
-                            <x-cube::badge
-                                :url="route('frontend.tags.show', [encode_id($tag->id), $tag->slug])"
-                                :text="$tag->name"
-                            />
-                        @endforeach
-                    </div>
-                </x-cube::card>
-            @endforeach
-        </div>
-        <div class="mt-8 w-full">
-            {{ $$module_name->links() }}
+                        {{-- Tags --}}
+                        @if ($$module_name_singular->tags->isNotEmpty())
+                            <div class="flex flex-wrap">
+                                @foreach ($$module_name_singular->tags as $tag)
+                                    <x-cube::badge
+                                        :url="route('frontend.tags.show', [encode_id($tag->id), $tag->slug])"
+                                        :text="$tag->name"
+                                    />
+                                @endforeach
+                            </div>
+                        @endif
+                    </x-cube::card>
+                @endforeach
+            </div>
+
+            <div class="mt-10">
+                {{ $$module_name->links() }}
+            </div>
         </div>
     </section>
 @endsection

--- a/src/Modules/Post/Resources/views/frontend/posts/show.blade.php
+++ b/src/Modules/Post/Resources/views/frontend/posts/show.blade.php
@@ -13,112 +13,122 @@
         if ($shareImage && ! \Illuminate\Support\Str::startsWith($shareImage, ["http://", "https://"])) {
             $shareImage = asset($shareImage);
         }
+
+        $authorName = $$module_name_singular->created_by_alias
+            ?: $$module_name_singular->created_by_name;
     @endphp
 
-    <section class="body-font bg-gray-100 px-6 text-gray-600 sm:px-20 dark:bg-gray-800 dark:text-gray-400">
-        <div class="container mx-auto flex flex-col items-center py-8 sm:py-16 md:flex-row">
-            <div
-                class="flex flex-col items-center text-center sm:w-4/12 md:items-start md:pr-16 md:text-left lg:flex-grow lg:pr-24"
-            >
-                <h1 class="mb-4 text-3xl font-medium text-gray-800 sm:text-4xl dark:text-gray-200">
-                    {{ $$module_name_singular->name }}
-                </h1>
-                @if ($$module_name_singular->intro != "")
-                    <p class="mb-8 leading-relaxed">
-                        {{ $$module_name_singular->intro }}
-                    </p>
-                @endif
+    {{-- Hero: two-column on desktop --}}
+    <section class="bg-gray-100 px-6 text-gray-600 sm:px-10 dark:bg-gray-800 dark:text-gray-400">
+        <div class="mx-auto max-w-6xl py-10 sm:py-14">
 
-                @include("frontend.includes.messages")
-            </div>
-            <div class="mb-4 w-full sm:mb-0 sm:w-8/12">
-                <img
-                    class="rounded object-cover object-center shadow-md"
-                    src="{{ $$module_name_singular->image }}"
-                    alt="{{ $$module_name_singular->name }}"
-                />
+            <div class="flex flex-col gap-8 lg:flex-row lg:items-center lg:gap-14">
+
+                {{-- Left: title, intro, meta --}}
+                <div class="flex flex-col lg:w-1/3">
+                    <h1 class="mb-4 text-3xl font-semibold leading-tight text-gray-800 sm:text-4xl dark:text-gray-100">
+                        {{ $$module_name_singular->name }}
+                    </h1>
+
+                    @if ($$module_name_singular->intro != "")
+                        <p class="mb-6 text-lg leading-relaxed text-gray-500 dark:text-gray-400">
+                            {{ $$module_name_singular->intro }}
+                        </p>
+                    @endif
+
+                    <div class="flex flex-wrap items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+                        <span class="flex items-center gap-1.5">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                            </svg>
+                            {{ $authorName }}
+                        </span>
+                        @if ($$module_name_singular->published_at)
+                            <span class="flex items-center gap-1.5">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                                </svg>
+                                {{ $$module_name_singular->published_at->isoFormat("ll") }}
+                            </span>
+                        @endif
+                    </div>
+
+                    @include("frontend.includes.messages")
+                </div>
+
+                {{-- Right: featured image --}}
+                @if ($$module_name_singular->image)
+                    <div class="lg:w-2/3">
+                        <img
+                            class="max-h-[420px] w-full rounded-xl object-cover shadow-md"
+                            src="{{ $$module_name_singular->image }}"
+                            alt="{{ $$module_name_singular->name }}"
+                        />
+                    </div>
+                @endif
             </div>
         </div>
     </section>
 
-    <section class="px-6 py-6 sm:px-20 sm:py-10 dark:bg-gray-700 dark:text-gray-300">
-        <div class="container mx-auto flex flex-col md:flex-row">
-            <div class="flex flex-col sm:w-8/12 sm:pr-8 lg:flex-grow">
-                <div class="pb-5">
-                    <p>
+    {{-- Body --}}
+    <section class="px-6 py-10 sm:px-10 sm:py-14 dark:bg-gray-700 dark:text-gray-300">
+        <div class="mx-auto max-w-6xl">
+            <div class="flex flex-col gap-10 lg:flex-row">
+
+                {{-- Main content --}}
+                <div class="min-w-0 lg:flex-1">
+                    <div class="prose prose-gray max-w-none dark:prose-invert prose-headings:font-semibold prose-a:text-blue-600 prose-img:rounded-lg prose-img:shadow-sm">
                         {!! $$module_name_singular->content !!}
-                    </p>
-                </div>
-
-                <hr />
-
-                <div class="py-5">
-                    <div class="flex flex-col justify-between sm:flex-row">
-                        <div class="pb-2">
-                            {{ __("Written by") }}:
-                            {{ isset($$module_name_singular->created_by_alias) ? $$module_name_singular->created_by_alias : $$module_name_singular->created_by_name }}
-                        </div>
-                        <div class="pb-2">
-                            {{ __("Published at") }}: {{ $$module_name_singular->published_at->isoFormat("llll") }}
-                        </div>
                     </div>
-                </div>
 
-                <div class="flex flex-row justify-between py-5">
-                    <div>
-                        <span class="font-weight-bold">
-                            @lang("Category")
-                            :
-                        </span>
-                        <x-cube::badge
-                            :url="route('frontend.categories.show', [
-                                encode_id($$module_name_singular->category_id),
-                                $$module_name_singular->category->slug,
-                            ])"
-                            :text="$$module_name_singular->category->name"
+                    <hr class="my-8 dark:border-gray-600" />
+
+                    {{-- Category --}}
+                    <div class="mb-4 flex items-center gap-2">
+                        <span class="text-sm font-semibold text-gray-600 dark:text-gray-400">{{ __("Category") }}:</span>
+                        <a
+                            href="{{ route('frontend.categories.show', [encode_id($$module_name_singular->category_id), $$module_name_singular->category->slug]) }}"
+                            class="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-700 hover:bg-blue-100 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-900/60"
+                        >
+                            {{ $$module_name_singular->category->name }}
+                        </a>
+                    </div>
+
+                    {{-- Tags --}}
+                    @if (count($$module_name_singular->tags))
+                        <div class="mb-6 flex flex-wrap items-center gap-1">
+                            <span class="text-sm font-semibold text-gray-600 dark:text-gray-400">{{ __("Tags") }}:</span>
+                            @foreach ($$module_name_singular->tags as $tag)
+                                <x-cube::badge
+                                    :url="route('frontend.tags.show', [encode_id($tag->id), $tag->slug])"
+                                    :text="$tag->name"
+                                />
+                            @endforeach
+                        </div>
+                    @endif
+
+                    {{-- Share --}}
+                    <div class="mt-6">
+                        <x-sharekit::buttons
+                            theme="tailwind"
+                            label="{{ __('Share with others') }}"
+                            :url="$shareUrl"
+                            :title="$$module_name_singular->name"
+                            :description="$shareDescription"
+                            :image="$shareImage"
+                            :networks="['x', 'facebook', 'linkedin', 'whatsapp', 'telegram', 'email', 'copy', 'native']"
+                            size="sm"
+                            :show-heading="true"
                         />
                     </div>
                 </div>
 
-                @if (count($$module_name_singular->tags))
-                    <div class="py-5">
-                        <span class="font-weight-bold">
-                            @lang("Tags")
-                            :
-                        </span>
-
-                        @foreach ($$module_name_singular->tags as $tag)
-                            <x-cube::badge
-                                :url="route('frontend.tags.show', [encode_id($tag->id), $tag->slug])"
-                                :text="$tag->name"
-                            />
-                        @endforeach
+                {{-- Sidebar --}}
+                <aside class="w-full shrink-0 lg:w-72">
+                    <div class="sticky top-6">
+                        <livewire:post.frontend-recent-posts />
                     </div>
-                @endif
-
-                <div class="py-5">
-                    <x-sharekit::buttons
-                        theme="tailwind"
-                        label="{{ __('Share with others') }}"
-                        :url="$shareUrl"
-                        :title="$$module_name_singular->name"
-                        :description="$shareDescription"
-                        :image="$shareImage"
-                        :networks="['x', 'facebook', 'linkedin', 'whatsapp', 'telegram', 'email', 'copy', 'native']"
-                        size="sm"
-                        :show-heading="true"
-                    />
-                </div>
-
-                <div class="py-5">
-                    
-                </div>
-            </div>
-
-            <div class="flex flex-col sm:w-4/12">
-                <div class="py-5 sm:pt-0">
-                    <livewire:post.frontend-recent-posts />
-                </div>
+                </aside>
             </div>
         </div>
     </section>

--- a/src/Modules/Post/Resources/views/livewire/frontend/recent-posts.blade.php
+++ b/src/Modules/Post/Resources/views/livewire/frontend/recent-posts.blade.php
@@ -1,61 +1,45 @@
-<div>
-    <div class="container mx-auto flex w-full flex-col items-center justify-center">
-        <div
-            class="mb-2 w-full rounded-md border bg-white px-4 py-5 shadow-sm dark:bg-gray-600 dark:text-gray-300 sm:px-6"
-        >
-            <h3 class="text-lg font-medium leading-6 text-gray-800 dark:text-gray-200">
-                @lang("Recent Posts")
-            </h3>
-            <p class="mt-1 max-w-2xl text-sm text-gray-500 dark:text-gray-200">Recently published articles!</p>
-        </div>
-        <ul class="flex w-full flex-col">
-            @foreach ($recentPosts as $row)
-                @php
-                    $details_url = route("frontend.posts.show", [encode_id($row->id), $row->slug]);
-                @endphp
+<div class="w-full rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
 
-                <li class="mb-2 flex flex-row border-gray-400">
-                    <div
-                        class="flex flex-1 transform cursor-pointer select-none items-center justify-between rounded-md bg-white p-4 shadow-sm transition duration-500 ease-in-out hover:-translate-y-1 hover:shadow-lg dark:bg-gray-600 dark:text-gray-300"
-                    >
-                        <div class="flex">
-                            <div class="mr-4 flex h-10 flex-col items-center justify-center">
-                                <a class="relative block" href="{{ $details_url }}">
-                                    <img
-                                        class="mx-auto h-10 rounded-sm object-cover"
-                                        src="{{ $row->image }}"
-                                        alt="{{ $row->name }}"
-                                    />
-                                </a>
-                            </div>
-                            <div class="pl-1">
-                                <div class="font-medium">
-                                    <a href="{{ $details_url }}">
-                                        {{ $row->name }}
-                                    </a>
-                                </div>
-                                <div class="text-sm text-gray-600 dark:text-gray-200">
-                                    {{ isset($row->created_by_alias) ? $row->created_by_alias : $row->created_by_name }}
-                                </div>
-                            </div>
-                        </div>
-                        <button class="flex w-6 justify-end text-right">
-                            <svg
-                                class="text-gray-500 hover:text-gray-800 dark:text-gray-200"
-                                width="12"
-                                fill="currentColor"
-                                height="12"
-                                viewBox="0 0 1792 1792"
-                                xmlns="http://www.w3.org/2000/svg"
-                            >
-                                <path
-                                    d="M1363 877l-742 742q-19 19-45 19t-45-19l-166-166q-19-19-19-45t19-45l531-531-531-531q-19-19-19-45t19-45l166-166q19-19 45-19t45 19l742 742q19 19 19 45t-19 45z"
-                                ></path>
-                            </svg>
-                        </button>
-                    </div>
-                </li>
-            @endforeach
-        </ul>
+    <div class="border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+        <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            @lang("Recent Posts")
+        </h3>
     </div>
+
+    <ul class="divide-y divide-gray-100 dark:divide-gray-700">
+        @foreach ($recentPosts as $row)
+            @php
+                $details_url = route("frontend.posts.show", [encode_id($row->id), $row->slug]);
+                $authorName = $row->created_by_alias ?: $row->created_by_name;
+            @endphp
+
+            <li>
+                <a
+                    href="{{ $details_url }}"
+                    wire:navigate
+                    class="flex items-start gap-3 px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                >
+                    <img
+                        class="mt-0.5 h-14 w-14 shrink-0 rounded object-cover"
+                        src="{{ $row->image }}"
+                        alt="{{ $row->name }}"
+                    />
+                    <div class="min-w-0 flex-1">
+                        <p class="line-clamp-2 text-sm font-medium leading-snug text-gray-800 dark:text-gray-200">
+                            {{ $row->name }}
+                        </p>
+                        <p class="mt-1 truncate text-xs text-gray-400 dark:text-gray-500">
+                            {{ $authorName }}
+                        </p>
+                        @if ($row->published_at)
+                            <p class="mt-0.5 text-xs text-gray-400 dark:text-gray-500">
+                                {{ $row->published_at->format("M j, Y") }}
+                            </p>
+                        @endif
+                    </div>
+                </a>
+            </li>
+        @endforeach
+    </ul>
+
 </div>


### PR DESCRIPTION
Refactor the frontend templates for the Post module to improve layout, responsiveness, and visual consistency.

- Update `posts/index.blade.php` with a new grid layout and improved author metadata display.
- Redesign `posts/show.blade.php` using a two-column hero section for better content hierarchy.
- Modernize `recent-posts.blade.php` Livewire component with a cleaner, more compact design.
- Wrap static text in translation helpers for better localization support.