### PR TITLE
fix: update image validation and handling in store and update methods

### DIFF
--- a/src/Modules/Post/Http/Controllers/Backend/PostsController.php
+++ b/src/Modules/Post/Http/Controllers/Backend/PostsController.php
@@ -60,7 +60,7 @@ class PostsController extends BackendBaseController
             'created_by_alias' => 'nullable|max:191',
             'intro' => 'required',
             'content' => 'required',
-            'image' => 'nullable|max:191',
+            'image' => 'nullable|image|max:2048',
             'category_id' => 'required|integer',
             'type' => Rule::enum(PostType::class),
             'is_featured' => 'required|integer',
@@ -74,11 +74,18 @@ class PostsController extends BackendBaseController
             'meta_og_image' => 'nullable|max:191',
         ]);
 
-        $data = Arr::except($validated_data, 'tags_list');
+        $imageFile = $validated_data['image'] ?? null;
+        $data = Arr::except($validated_data, ['tags_list', 'image']);
         $data['created_by_name'] = Auth::user()->name;
 
         $$module_name_singular = $module_model::create($data);
         $$module_name_singular->tags()->attach($request->input('tags_list'));
+
+        if ($imageFile) {
+            $media = $$module_name_singular->addMedia($imageFile)->toMediaCollection($module_name);
+            $$module_name_singular->image = $media->getUrl();
+            $$module_name_singular->save();
+        }
 
         flash("New '".Str::singular($module_title)."' Added")->success()->important();
 
@@ -115,7 +122,7 @@ class PostsController extends BackendBaseController
             'created_by_alias' => 'nullable|max:191',
             'intro' => 'required',
             'content' => 'required',
-            'image' => 'nullable|max:191',
+            'image' => 'nullable|image|max:2048',
             'category_id' => 'required|integer',
             'type' => Rule::enum(PostType::class),
             'is_featured' => 'required|integer',
@@ -129,11 +136,19 @@ class PostsController extends BackendBaseController
             'meta_og_image' => 'nullable|max:191',
         ]);
 
-        $data = Arr::except($validated_data, 'tags_list');
+        $imageFile = $validated_data['image'] ?? null;
+        $data = Arr::except($validated_data, ['tags_list', 'image']);
 
         $$module_name_singular = $module_model::findOrFail($id);
 
         $$module_name_singular->update($data);
+
+        if ($imageFile) {
+            $$module_name_singular->clearMediaCollection($module_name);
+            $media = $$module_name_singular->addMedia($imageFile)->toMediaCollection($module_name);
+            $$module_name_singular->image = $media->getUrl();
+            $$module_name_singular->save();
+        }
 
         if ($request->input('tags_list') === null) {
             $tags_list = [];


### PR DESCRIPTION
This pull request updates the image upload and validation logic for posts in the backend. The main improvements are stricter image validation and proper handling of image file uploads and associations when creating or updating a post.

**Image validation and handling improvements:**

* The `image` field validation now requires the uploaded file to be an image and increases the maximum file size to 2MB (`max:2048`), instead of just checking the string length. [[1]](diffhunk://#diff-354954c2783334f5d0a897b214497fcf471638e7ca15870760793086cf0bbb17L63-R63) [[2]](diffhunk://#diff-354954c2783334f5d0a897b214497fcf471638e7ca15870760793086cf0bbb17L118-R125)
* When storing a new post, the uploaded image file is now properly saved to the media collection, and the post's `image` attribute is updated with the resulting URL.
* When updating a post, if a new image is uploaded, the old image is cleared from the media collection, the new image is saved, and the post's `image` attribute is updated accordingly.
* The image file is removed from the main data array before saving the post, ensuring it is only handled via the media library. [[1]](diffhunk://#diff-354954c2783334f5d0a897b214497fcf471638e7ca15870760793086cf0bbb17L77-R89) [[2]](diffhunk://#diff-354954c2783334f5d0a897b214497fcf471638e7ca15870760793086cf0bbb17L132-R152)